### PR TITLE
feat(RAN-18): Playwright production pipeline foundation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "playwright-linear-styleframes",
+  "version": "0.1.0",
+  "private": true,
+  "type": "commonjs",
+  "scripts": {
+    "test": "playwright test --config=playwright.config.ts",
+    "iterate": "npx tsx generate-playwright-config.ts && playwright test --config=playwright.config.generated.ts",
+    "generate:config": "npx tsx generate-playwright-config.ts",
+    "test:styleframes": "playwright test tests/styleframes.spec.ts --config=playwright.config.ts"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.56.1",
+    "dotenv": "^17.2.3",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from "@playwright/test";
+import dotenv from "dotenv";
+import { STYLEFRAME_FIXTURES } from "./tests/fixtures/styleframes.catalog";
+
+dotenv.config();
+
+const defaultProjects = STYLEFRAME_FIXTURES.map((styleframe) => ({
+  name: styleframe.issueId,
+  testMatch: ["tests/styleframes.spec.ts"],
+  use: {
+    styleframe,
+    expectToFail: true,
+  },
+}));
+
+export default defineConfig({
+  testDir: ".",
+  timeout: 120_000,
+  fullyParallel: false,
+  retries: 0,
+  reporter: [
+    ["list"],
+    ["html", { open: "never" }],
+    ["./reporters/linear-reporter.ts"],
+  ],
+  projects: defaultProjects,
+} as any);

--- a/playwright.dummy.config.ts
+++ b/playwright.dummy.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "tests",
+  testMatch: "dummy.spec.ts",
+  fullyParallel: true,
+  retries: 0,
+  reporter: [["list"]],
+  use: {
+    baseURL: "https://example.com",
+  },
+});

--- a/tests/dummy.spec.ts
+++ b/tests/dummy.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "@playwright/test";
+
+test("dummy test - check page title", async ({ page }) => {
+  // Navigate to example.com
+  await page.goto("https://example.com");
+
+  // Check that the page has the expected title
+  await expect(page).toHaveTitle(/example/i);
+});
+
+test("dummy test - verify heading exists", async ({ page }) => {
+  // Navigate to example.com
+  await page.goto("https://example.com");
+
+  // Check that the h1 heading exists
+  const heading = page.locator("h1");
+  await expect(heading).toBeVisible();
+});

--- a/tests/helpers/assets.ts
+++ b/tests/helpers/assets.ts
@@ -1,0 +1,15 @@
+import fs from "fs";
+import path from "path";
+
+export function saveAsset(buffer: Buffer, relativePath: string): string {
+  const outputDir = path.resolve(__dirname, "..", "..", "test-results", "assets");
+  const fullPath = path.join(outputDir, relativePath);
+  const dir = path.dirname(fullPath);
+
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  fs.writeFileSync(fullPath, buffer);
+  return fullPath;
+}


### PR DESCRIPTION
## Summary

Core scaffolding for the Playwright-as-production-pipeline architecture (RAN-18).

- `package.json` — deps + scripts (`test`, `iterate`, `generate:config`, `test:styleframes`)
- `playwright.config.ts` — maps STYLEFRAME_FIXTURES to per-issue projects, wires linear-reporter, 120s timeout
- `playwright.dummy.config.ts` + `tests/dummy.spec.ts` — sanity check harness
- `tests/helpers/assets.ts` — persists generated buffers to `test-results/assets/{beat}/{issueId}/`

## Test plan

- [ ] `npm install` runs clean
- [ ] `npx playwright test --config playwright.dummy.config.ts` passes (example.com sanity)
- [ ] `npm run test:styleframes` runs in dry-run mode without errors

Closes RAN-18

🤖 Generated with [Claude Code](https://claude.com/claude-code)